### PR TITLE
Ensure dseq supports being passed a list of inputs

### DIFF
--- a/doc/namespaces.md
+++ b/doc/namespaces.md
@@ -261,6 +261,14 @@ de/muxing classes like `AvroMultipleOutputs`.
      (r/take 1)
      (into []))
 ;;=> ["(defproject com.damballa/parkour"]
+
+;;Or with multiple inputs
+
+(->> (apply text/dseq (fs/path-glob "2014-*-*"))
+     (r/map second)
+     (r/map #(subs % 0 32))
+     (r/take 1)
+     (into [])))
 ```
 
 ## Job graph API


### PR DESCRIPTION
I was struggling to get `dseq` to work with a list of input sources from a glob:

``` clojure
(seqf/seq (fs/path-glob "/*.blah"))
```

But this does not work since you have to call seq with apply:

``` clojure
(apply seqf/dseq (fs/path-glob "/*.blah")))
```

Since the & paths is a list of lists in the first example:
https://github.com/damballa/parkour/blob/master/src/clojure/parkour/io/seqf.clj#L12

This felt a bit odd so I thought I would suggest a patch to allow both forms to work. I've tried to maintain the existing api and avoid any breaking changes.

Warning: written without :coffee:
