### PR TITLE
Load namespaces during record-reader setup.

### DIFF
--- a/src/clojure/parkour/remote/common.clj
+++ b/src/clojure/parkour/remote/common.clj
@@ -1,0 +1,50 @@
+(ns parkour.remote.common
+  {:private true}
+  (:require [clojure.tools.logging :as log]
+            [parkour (cser :as cser) (mapreduce :as mr)]
+            [parkour.util :refer [returning]]))
+
+(defn ^:private try-require*
+  "Attempt to `require` namespace by symbol `ns`.  On success return `true` and
+on failure log and return `false`."
+  [ns]
+  (try
+    (returning true (require ns))
+    (catch Throwable e
+      (returning false
+        (log/warnf e "%s: failed to load namespace." ns)))))
+
+(defn ^:private ns-child-fn
+  "Return function which returns true iff the provided namespace-symbol is a
+child of namespace-symbol `prefix`."
+ [prefix]
+  (let [prefix (str (name prefix) ".")]
+    (fn [sym] (.startsWith (name sym) prefix))))
+
+(defn try-require
+  "Load the namespaces `nses`.  On failure loading any particular namespace,
+skip namespaces which are children of the failing namespace."
+  [& nses]
+  (loop [nses (sort nses)]
+    (when-let [[ns & nses] (seq nses)]
+      (if (try-require* ns)
+        (recur nses)
+        (recur (drop-while (ns-child-fn ns) nses))))))
+
+(defn conf-require!
+  "Load any namespaces specified by the value at `conf`'s \"parkour.namespaces\"
+  key, skipping any which fail to load or are children of ones which fail to
+  load, then replace the configuration value with the empty set."
+  [conf]
+  (apply try-require (cser/get conf "parkour.namespaces" #{}))
+  (cser/assoc! conf "parkour.namespaces" #{}))
+
+(defn adapt
+  "Apply adapter function specified by var `v` via `::mr/adapter` metadata --
+`default` if unspecified -- to the value of `v` and return resulting function."
+  [default v]
+  (let [m (meta v)
+        w (if (::mr/raw m)
+            identity
+            (::mr/adapter m default))]
+    (w (with-meta @v m))))

--- a/src/clojure/parkour/remote/input.clj
+++ b/src/clojure/parkour/remote/input.clj
@@ -1,6 +1,6 @@
 (ns parkour.remote.input
   (:require [parkour (conf :as conf) (cser :as cser) (mapreduce :as mr)]
-            [parkour.remote.basic :refer [adapt]]
+            [parkour.remote.common :refer [adapt conf-require!]]
             [parkour.util :refer [coerce]])
   (:import [parkour.hadoop EdnInputSplit]
            [org.apache.hadoop.mapreduce
@@ -23,6 +23,7 @@
 (defn create-record-reader
   "Generic Parkour `InputFormat#createRecordReader()` implementation."
   [id ^InputSplit split ^TaskAttemptContext context]
+  (conf-require! context)
   (let [key (str "parkour.input-format." id)
         rvar (cser/get context (str key ".rvar"))
         args (cser/get context (str key ".rargs"))


### PR DESCRIPTION
Creating an in-Clojure record-reader instance may depend on namespaces not directly in the serialized var dependency set, such as for multimethod or protocol implementations.  In order to achieve the desired namespace loading behavior without depending on the order in which the Hadoop implementation happens to create/initialize aspects of the task, we need to try to load namespaces during both record-reader and task-function initialization.
